### PR TITLE
chore(config): add vitest type reference to vite configuration

### DIFF
--- a/mergestats-ui/vite.config.ts
+++ b/mergestats-ui/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 


### PR DESCRIPTION
- Add TypeScript reference directive for vitest/config types
- Enables proper type checking and IDE support for vitest configuration
- Improves development experience with better type hints in vite.config.ts